### PR TITLE
docs: auth documentation and richer usage examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-17
+
+### Changed
+- Add authentication documentation (Basic Auth and token-based) to README
+- Expand usage examples with real-world flows and scenarios
+
 ## [0.2.0] - 2026-04-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlflow-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Model Context Protocol (MCP) server for MLflow - enables LLMs to interact with MLflow experiments, runs, metrics, and models"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Add authentication docs (Basic Auth and token-based) to README Configuration section
- Add Authenticated Server config example with both username/password and token flows
- Expand Usage Examples with real-world flows: experiment exploration, run analysis, model registration, registry management, end-to-end promotion

## Test plan
- [ ] README renders correctly on GitHub
- [ ] All config JSON examples are valid