### PR TITLE
add audit_mlflow_setup prompt and get_experiment_tags tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-22
+
+### Added
+- `get_experiment_tags(experiment_id)` — discover all unique tag keys used across runs in an experiment (completes the metrics/params/tags symmetrical trio)
+- `audit_mlflow_setup` prompt — evaluates an MLflow deployment against Google/Databricks best practices across 7 categories (experiment organization, parameter logging, metric logging, tagging strategy, artifact management, model registry, reproducibility); scores each 1–10 and produces a prioritized improvement roadmap with a mean score
+
+### Changed
+- `get_run()` now returns an `inputs` field containing dataset inputs logged via `mlflow.log_input()` (MLflow 3 dataset tracking)
+
 ## [0.3.0] - 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ For Databricks or token-based auth, use `MLFLOW_TRACKING_TOKEN` instead:
 | `get_experiment_by_name(name)` | Get experiment by name |
 | `get_experiment_metrics(experiment_id)` | Discover all unique metric keys |
 | `get_experiment_params(experiment_id)` | Discover all unique parameter keys |
+| `get_experiment_tags(experiment_id)` | Discover all unique tag keys used across runs |
 | `set_experiment_tag(experiment_id, key, value)` | Tag an experiment |
 | `delete_experiment(experiment_id)` | Delete an experiment (moves to deleted stage) |
 
@@ -142,7 +143,7 @@ For Databricks or token-based auth, use `MLFLOW_TRACKING_TOKEN` instead:
 | Tool | Description |
 |---|---|
 | `get_runs(experiment_id, limit, offset, order_by)` | List runs with full details, sorting and pagination |
-| `get_run(run_id)` | Get detailed run information |
+| `get_run(run_id)` | Get detailed run information including metrics, params, tags, artifact URI, and dataset inputs |
 | `get_parent_run(run_id)` | Get parent run for nested runs |
 | `query_runs(experiment_id, query, limit, offset, order_by)` | Filter runs, e.g. `"metrics.accuracy > 0.9"` |
 | `search_runs_by_tags(experiment_id, tags, limit, offset)` | Find runs by tag key/value |
@@ -213,6 +214,7 @@ Built-in guided workflows available as slash commands in Claude:
 | `compare_runs_by_ids` | Compare specific runs side-by-side |
 | `find_best_run` | Find and analyze the best run in an experiment by metric |
 | `promote_best_model` | End-to-end: find best model → register → tag → alias → promote |
+| `audit_mlflow_setup` | Audit the MLflow setup against industry best practices — scores 7 categories 1–10 and produces a prioritized improvement roadmap |
 
 ## Usage Examples
 
@@ -251,6 +253,35 @@ Built-in guided workflows available as slash commands in Claude:
 > "Update the description of fraud-classifier v3 to explain what dataset it was trained on."
 
 > "Copy fraud-classifier v3 to a separate 'fraud-classifier-prod' model as the production entry."
+
+### Audit your MLflow setup
+
+> "Audit my MLflow setup"
+
+*(Triggers the `audit_mlflow_setup` built-in prompt — Claude explores experiments, runs, artifacts, and the model registry, then scores each area against Google/Databricks best practices)*
+
+<details>
+<summary>Example output</summary>
+
+```
+| Category             | Score  | Top Issue                                      |
+|----------------------|--------|------------------------------------------------|
+| Experiment Org       |  5/10  | Flat namespace, no dot-notation hierarchy      |
+| Parameter Logging    |  7/10  | No parent-child nesting for tuning sweeps      |
+| Metric Logging       |  6/10  | Only final values logged, no training curves   |
+| Tagging Strategy     |  5/10  | Params duplicated as tags; stale test_tag      |
+| Artifact Management  |  2/10  | No log_model(); artifacts on local disk        |
+| Model Registry       |  3/10  | Duplicate prod models instead of aliases       |
+| Reproducibility      |  3/10  | No git SHA; no mlflow.log_input() datasets     |
+| Mean Score           |  4.4/10|                                                |
+
+Top 3 improvements:
+1. Call log_model() and move artifact store to S3/GCS
+2. Add git SHA tag + mlflow.log_input() for dataset tracking
+3. Consolidate registry to one model entry with @champion alias
+```
+
+</details>
 
 ### End-to-end promotion workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlflow-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "A Model Context Protocol (MCP) server for MLflow - enables LLMs to interact with MLflow experiments, runs, metrics, and models"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mlflow_mcp/__init__.py
+++ b/src/mlflow_mcp/__init__.py
@@ -1,3 +1,3 @@
 """MLflow MCP Server - A Model Context Protocol server for MLflow."""
 
-__version__ = "0.1.7"
+__version__ = "0.4.0"

--- a/src/mlflow_mcp/server.py
+++ b/src/mlflow_mcp/server.py
@@ -1248,7 +1248,7 @@ _AUDIT_PROMPT = """You are a senior MLOps consultant auditing this MLflow deploy
     </category>
 
     <category name="artifact_management">
-      <best_practice>log_model() not just log_artifact(); artifact_uri points to cloud storage (s3://, gs://) not local paths in production; model cards, feature schemas, validation results included; organized paths (model/, data/, results/).</best_practice>
+      <best_practice>log_model() not just log_artifact(); artifact_uri points to cloud storage (s3://, gs://) or uses the MLflow proxy (mlflow-artifacts:/) backed by cloud — not bare file:// local paths in production; model cards, feature schemas, validation results included; organized paths (model/, data/, results/).</best_practice>
       <whats_good></whats_good>
       <whats_bad></whats_bad>
       <what_to_improve></what_to_improve>

--- a/src/mlflow_mcp/server.py
+++ b/src/mlflow_mcp/server.py
@@ -154,6 +154,25 @@ def get_experiment_params(experiment_id: str) -> list[str]:
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+def get_experiment_tags(experiment_id: str) -> list[str]:
+    """Get all unique tag keys used across all runs in an experiment"""
+    logger.info(f"Fetching tags for experiment: {experiment_id}")
+    try:
+        client = MlflowClient()
+        runs = client.search_runs(experiment_ids=[experiment_id], max_results=1000)
+
+        tag_keys = set()
+        for run in runs:
+            tag_keys.update(run.data.tags.keys())
+
+        logger.info(f"Found {len(tag_keys)} unique tag keys across {len(runs)} runs")
+        return sorted(list(tag_keys))
+    except Exception as e:
+        logger.error(f"Error fetching tags for experiment {experiment_id}: {e}")
+        raise
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 def get_runs(
     experiment_id: str,
     limit: int = 3,
@@ -228,6 +247,15 @@ def get_run(run_id: str) -> dict:
             "metrics": run.data.metrics,
             "params": run.data.params,
             "tags": run.data.tags,
+            "inputs": [
+                {
+                    "name": di.dataset.name,
+                    "digest": di.dataset.digest,
+                    "source_type": di.dataset.source_type,
+                    "tags": {t.key: t.value for t in di.tags},
+                }
+                for di in (run.inputs.dataset_inputs or [])
+            ],
         }
     except Exception as e:
         logger.error(f"Error fetching run {run_id}: {e}")
@@ -1159,6 +1187,120 @@ Add relevant model-level tags (problem_type, framework, asset). Tag the source r
 Assign the "champion" alias to the new version.
 Ask the user if they want to copy it to a separate production model entry.
 Summarize what was done."""
+
+
+_AUDIT_PROMPT = """You are a senior MLOps consultant auditing this MLflow deployment against Google/Databricks industry best practices.
+
+<instructions>
+  <step name="gather_data">
+    Call tools in this order to collect evidence before evaluating anything.
+
+    1. get_experiments() — list all experiments; note names, count, naming patterns
+    2. For up to 3 representative experiments:
+       - get_experiment_metrics(experiment_id)
+       - get_experiment_params(experiment_id)
+       - get_experiment_tags(experiment_id)
+       - get_runs(experiment_id, limit=5)
+    3. For up to 3 individual runs sampled above:
+       - get_run(run_id) — inspect params, metrics, tags, artifact_uri, inputs
+       - get_run_artifacts(run_id) — inspect artifact structure and file names
+    4. get_registered_models()
+    5. For up to 2 registered models:
+       - get_registered_model(name) — check aliases
+       - get_model_versions(name) — check versioning, descriptions, stages
+
+    <note>If the instance has very few runs, treat missing data as "unknown" not "bad". Score only what you can observe.</note>
+  </step>
+
+  <step name="evaluate">
+    Score each category 1–10 and fill in the structured blocks below.
+
+    <category name="experiment_organization">
+      <best_practice>Hierarchical dot-notation names (team.project.task); consistent convention; no generic names like "test", "Default", "my_experiment"; searchable by business context.</best_practice>
+      <whats_good></whats_good>
+      <whats_bad></whats_bad>
+      <what_to_improve></what_to_improve>
+      <score>X/10</score>
+    </category>
+
+    <category name="parameter_logging">
+      <best_practice>All hyperparameters logged at run start via log_params(); descriptive names ("learning_rate" not "lr"); parent-child run structure for tuning sweeps.</best_practice>
+      <whats_good></whats_good>
+      <whats_bad></whats_bad>
+      <what_to_improve></what_to_improve>
+      <score>X/10</score>
+    </category>
+
+    <category name="metric_logging">
+      <best_practice>train/val/test metrics logged separately with consistent prefixes; per-step logging for training progression (not just final values); business metrics alongside technical ones; no mixed naming ("acc" vs "accuracy").</best_practice>
+      <whats_good></whats_good>
+      <whats_bad></whats_bad>
+      <what_to_improve></what_to_improve>
+      <score>X/10</score>
+    </category>
+
+    <category name="tagging_strategy">
+      <best_practice>Tags = mutable categorical metadata for filtering (env, model_type, dataset_version, team); params = immutable training config; never store hyperparameters as tags; consistent naming convention.</best_practice>
+      <whats_good></whats_good>
+      <whats_bad></whats_bad>
+      <what_to_improve></what_to_improve>
+      <score>X/10</score>
+    </category>
+
+    <category name="artifact_management">
+      <best_practice>log_model() not just log_artifact(); artifact_uri points to cloud storage (s3://, gs://) not local paths in production; model cards, feature schemas, validation results included; organized paths (model/, data/, results/).</best_practice>
+      <whats_good></whats_good>
+      <whats_bad></whats_bad>
+      <what_to_improve></what_to_improve>
+      <score>X/10</score>
+    </category>
+
+    <category name="model_registry">
+      <best_practice>Descriptive model names (churn_xgboost, not model1); version descriptions capture key differences; aliases used (champion, production) for routing; versions linked to source runs.</best_practice>
+      <whats_good></whats_good>
+      <whats_bad></whats_bad>
+      <what_to_improve></what_to_improve>
+      <score>X/10</score>
+    </category>
+
+    <category name="reproducibility">
+      <best_practice>Git commit SHA in tags (mlflow.source.git.commit); random seeds logged as params; datasets tracked via mlflow.log_input() (visible in run inputs); dependency versions captured (requirements.txt in artifacts).</best_practice>
+      <whats_good></whats_good>
+      <whats_bad></whats_bad>
+      <what_to_improve></what_to_improve>
+      <score>X/10</score>
+    </category>
+  </step>
+
+  <step name="report">
+    Present a summary table:
+
+    | Category | Score | Top Issue |
+    |---|---|---|
+    | Experiment Organization | X/10 | … |
+    | Parameter Logging | X/10 | … |
+    | Metric Logging | X/10 | … |
+    | Tagging Strategy | X/10 | … |
+    | Artifact Management | X/10 | … |
+    | Model Registry | X/10 | … |
+    | Reproducibility | X/10 | … |
+    | **Mean Score** | **X.X/10** | |
+
+    Then list the 3 most impactful improvements with specific actionable steps.
+  </step>
+</instructions>
+"""
+
+
+@mcp.prompt()
+def audit_mlflow_setup() -> str:
+    """Audit the current MLflow setup against industry best practices.
+
+    Evaluates experiment organization, run logging quality, tagging strategy,
+    artifact management, model registry usage, production workflow, and reproducibility.
+    Each category is scored 1–10. Ends with a mean score and improvement roadmap.
+    """
+    return _AUDIT_PROMPT
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))


### PR DESCRIPTION
## Summary

- Adds `get_experiment_tags(experiment_id)` tool — completes the symmetrical trio with `get_experiment_metrics` and `get_experiment_params`; aggregates all unique tag keys across runs in an experiment
- Extends `get_run()` to include an `inputs` field exposing MLflow 3 dataset tracking (`mlflow.log_input()`)
- Adds `audit_mlflow_setup` MCP prompt — acts as an MLOps consultant that explores the current MLflow setup using existing tools, evaluates it across 7 categories (experiment organization, parameter logging, metric logging, tagging strategy, artifact management, model registry, reproducibility), scores each 1–10, and produces a mean score with a prioritized improvement roadmap
- Prompt text extracted as a `_AUDIT_PROMPT` module-level constant to keep the function body clean