### PR TITLE
add Dependabot config for weekly pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable weekly Dependabot security update PRs for pip dependencies (`mlflow`, `mcp`).